### PR TITLE
Fix centralManager:didRetrieveConnectedPeripherals won't be called when

### DIFF
--- a/YmsCoreBluetooth/YMSCBCentralManager.m
+++ b/YmsCoreBluetooth/YMSCBCentralManager.m
@@ -184,6 +184,7 @@ NSString *const YMSCBVersion = @"" kYMSCBVersion;
 
 - (NSArray *)retrieveConnectedPeripheralsWithServices:(NSArray *)serviceUUIDs {
     NSArray *result = [self.manager retrieveConnectedPeripheralsWithServices:serviceUUIDs];
+    [self centralManager:self.manager didRetrieveConnectedPeripherals:result];
     return result;
 }
 


### PR DESCRIPTION
Hi, I tried to fix the problem which centralManager delegate method won't be called.
