### PR TITLE
invalidate peripheral after connection established or failed

### DIFF
--- a/YmsCoreBluetooth/YMSCBPeripheral.m
+++ b/YmsCoreBluetooth/YMSCBPeripheral.m
@@ -176,11 +176,7 @@
 }
 
 - (void)resetWatchdog {
-    if (self.watchdogTimer) {
-        [self.watchdogTimer invalidate];
-        self.watchdogTimer = nil;
-        self.watchdogRaised = NO;
-    }
+    [self invalidateWatchDog];
 
     NSTimer *timer = [NSTimer scheduledTimerWithTimeInterval:self.watchdogTimerInterval
                                                       target:self
@@ -190,6 +186,13 @@
     self.watchdogTimer = timer;
 }
 
+- (void)invalidateWatchDog {
+    if (self.watchdogTimer) {
+        [self.watchdogTimer invalidate];
+        self.watchdogTimer = nil;
+        self.watchdogRaised = NO;
+    }
+}
 
 - (void)watchdogDisconnect {
     // Watchdog aware method
@@ -216,6 +219,8 @@
 
 - (void)handleConnectionResponse:(NSError *)error {
     YMSCBPeripheralConnectCallbackBlockType callback = [self.connectCallback copy];
+    
+    [self invalidateWatchDog];
     
     if (callback) {
         callback(self, error);


### PR DESCRIPTION
Hi, I added watchedog invalidate method right after the connection has been established or failed.
