### PR TITLE
Fixes a race condition with characteristic value

### DIFF
--- a/YmsCoreBluetooth/YMSCBCharacteristic.h
+++ b/YmsCoreBluetooth/YMSCBCharacteristic.h
@@ -134,8 +134,8 @@ typedef void (^YMSCBWriteCallbackBlockType)(NSError *);
  When notifyValue is YES, then cbCharacterisic is set to notify upon any changes to its value. 
  When notifyValue is NO, then no notifications are sent.
  
- An implementation of the method [YMSCBService notifyCharacteristicHandler:error:] is used to handle
- updates to cbCharacteristic. Note that notification handling is done at the YMSCBService level via 
+ An implementation of the method [YMSCBService notifyCharacteristicHandler:value:error:] is used to handle
+ updates to cbCharacteristic. Note that notification handling is done at the YMSCBService level via
  method handler and not by callback blocks. The reason for this is opinion: It is more convenient to
  write a method handler to deal with non-deterministic, asynchronous notification events than it is with blocks.
  

--- a/YmsCoreBluetooth/YMSCBPeripheral.m
+++ b/YmsCoreBluetooth/YMSCBPeripheral.m
@@ -365,13 +365,13 @@
  */
 - (void)peripheral:(CBPeripheral *)peripheral didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic error:(NSError *)error {
     __weak YMSCBPeripheral *this = self;
+    NSData *value = characteristic.value.copy;
     _YMS_PERFORM_ON_MAIN_THREAD(^{
         YMSCBService *btService = [this findService:characteristic.service];
         YMSCBCharacteristic *yc = [btService findCharacteristic:characteristic];
         
         if (yc.cbCharacteristic.isNotifying) {
-            [btService notifyCharacteristicHandler:yc error:error];
-            
+            [btService notifyCharacteristicHandler:yc value:value error:error];
         } else {
             if ([yc.readCallbacks count] > 0) {
                 [yc executeReadCallback:characteristic.value error:error];
@@ -434,6 +434,8 @@
  */
 - (void)peripheral:(CBPeripheral *)peripheral didWriteValueForCharacteristic:(CBCharacteristic *)characteristic error:(NSError *)error {
     __weak YMSCBPeripheral *this = self;
+    NSData *value = characteristic.value.copy;
+
     _YMS_PERFORM_ON_MAIN_THREAD(^{
         
         YMSCBService *btService = [this findService:characteristic.service];
@@ -443,7 +445,7 @@
             [yc executeWriteCallback:error];
         } else {
             // TODO is this dangerous?
-            [btService notifyCharacteristicHandler:yc error:error];
+            [btService notifyCharacteristicHandler:yc value:value error:error];
         }
         
         if ([this.delegate respondsToSelector:@selector(peripheral:didWriteValueForCharacteristic:error:)]) {

--- a/YmsCoreBluetooth/YMSCBService.h
+++ b/YmsCoreBluetooth/YMSCBService.h
@@ -45,8 +45,8 @@ typedef NS_ENUM(NSInteger, YMSCBCallbackTransactionType) {
  YMSCBService holds an instance of CBService (cbService).
  
  This class is typically subclassed to map to a service in a BLE peripheral. The subclass
- typically implements notifyCharacteristicHandler:error: to handle characteristics whose
- BLE notification has been enabled. 
+ typically implements notifyCharacteristicHandler:value:error: to handle characteristics whose
+ BLE notification has been enabled.
  */
 
 @interface YMSCBService : NSObject
@@ -183,10 +183,10 @@ typedef NS_ENUM(NSInteger, YMSCBCallbackTransactionType) {
  This method is typically overridden to handle characteristics whose notification has been turned on.
  
  @param yc Characteristic receiving update.
+ @param value The value of the characteristic
  @param error Error object.
  */
-- (void)notifyCharacteristicHandler:(YMSCBCharacteristic *)yc error:(NSError *)error;
-
+- (void)notifyCharacteristicHandler:(YMSCBCharacteristic *)yc value:(NSData *)value error:(NSError *)error;
 
 /**
  Discover characteristics for this service.

--- a/YmsCoreBluetooth/YMSCBService.m
+++ b/YmsCoreBluetooth/YMSCBService.m
@@ -199,7 +199,7 @@
 }
 
 
-- (void)notifyCharacteristicHandler:(YMSCBCharacteristic *)yc error:(NSError *)error {
+- (void)notifyCharacteristicHandler:(YMSCBCharacteristic *)yc value:(NSData *)value error:(NSError *)error {
     if (error) {
         return;
     }


### PR DESCRIPTION
We love this library! Thank you for all your time to create such library!
We recently hit a small issue and wanted to do PR for it. 
Looking at the internal didUpdateValueForCharacteristic delegate method , it sends the data method using a "perform on main thread" and it doesn't capture the data - it just sends a reference to the characteristic. This caused a race condition where some of the data we need off from the characteristics got overwritten by the time we access it. 
I added a NSData pointer which gets a copy of the characteristic's data and passes it along.